### PR TITLE
Add option to use custom shell

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const childProcess = require('child_process');
 const execa = require('execa');
 const stripAnsi = require('strip-ansi');
 const defaultShell = require('default-shell');
@@ -17,25 +16,24 @@ function parseEnv(env) {
 	return ret;
 }
 
-module.exports = () => {
+module.exports = shell => {
 	if (process.platform === 'win32') {
 		return Promise.resolve(process.env);
 	}
 
-	return execa(defaultShell, args)
+	return execa(shell || defaultShell, args)
 		.then(x => parseEnv(x.stdout))
 		.catch(() => process.env);
 };
 
-module.exports.sync = () => {
+module.exports.sync = shell => {
 	if (process.platform === 'win32') {
 		return process.env;
 	}
 
 	try {
-		// TODO: use `execa` → https://github.com/sindresorhus/execa/issues/7
-		const stdout = childProcess.execFileSync(defaultShell, args, {encoding: 'utf8'});
-		return parseEnv(stdout.trim());
+		const stdout = execa.sync(shell || defaultShell, args);
+		return parseEnv(stdout);
 	} catch (err) {
 		return process.env;
 	}

--- a/index.js
+++ b/index.js
@@ -23,7 +23,13 @@ module.exports = shell => {
 
 	return execa(shell || defaultShell, args)
 		.then(x => parseEnv(x.stdout))
-		.catch(() => process.env);
+		.catch(err => {
+			if (shell) {
+				throw err;
+			} else {
+				return process.env;
+			}
+		});
 };
 
 module.exports.sync = shell => {
@@ -32,9 +38,13 @@ module.exports.sync = shell => {
 	}
 
 	try {
-		const stdout = execa.sync(shell || defaultShell, args);
+		const stdout = execa.sync(shell || defaultShell, args).stdout;
 		return parseEnv(stdout);
 	} catch (err) {
-		return process.env;
+		if (shell) {
+			throw err;
+		} else {
+			return process.env;
+		}
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -19,18 +19,29 @@ const shellEnv = require('shell-env');
 
 console.log(shellEnv.sync());
 //=> {TERM_PROGRAM: 'Apple_Terminal', SHELL: '/bin/zsh', ...}
+
+console.log(shellEnv.sync('/bin/bash'));
+//=> {TERM_PROGRAM: 'iTerm.app', SHELL: '/bin/zsh', ...}
 ```
 
 
 ## API
 
-### shellEnv()
+### shellEnv([shell])
 
 Return a promise for the environment variables.
 
-### shellEnv.sync()
+
+### shellEnv.sync([shell])
 
 Returns the environment variables.
+
+#### shell
+
+Type: `string`
+
+Optionally pass in a shell to read the environment variables from.
+If no shell is passed [default-shell](https://github.com/sindresorhus/default-shell) will be used.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -27,10 +27,10 @@ test('sync with custom shell', t => {
 	t.false('' in env);
 });
 
-test('sync with custom shell throws on non-executable', async t => {
+test('sync with custom shell throws on non-executable', t => {
 	t.throws(() => m.sync('non-executable'));
 });
 
 test('async with custom shell throws on non-executable', async t => {
-	await t.throws(m('non-executable'));
+	t.throws(m('non-executable'));
 });

--- a/test.js
+++ b/test.js
@@ -26,3 +26,11 @@ test('sync with custom shell', t => {
 	t.true('HOME' in env);
 	t.false('' in env);
 });
+
+test('sync with custom shell throws on non-executable', async t => {
+	t.throws(() => m.sync('non-executable'));
+});
+
+test('async with custom shell throws on non-executable', async t => {
+	await t.throws(m('non-executable'));
+});

--- a/test.js
+++ b/test.js
@@ -12,3 +12,17 @@ test('sync', t => {
 	t.true('HOME' in env);
 	t.false('' in env);
 });
+
+test('async with custom shell', async t => {
+	const shell = '/bin/bash';
+	const env = await m(shell);
+	t.true('HOME' in env);
+	t.false('' in env);
+});
+
+test('sync with custom shell', t => {
+	const shell = '/bin/bash';
+	const env = m.sync(shell);
+	t.true('HOME' in env);
+	t.false('' in env);
+});


### PR DESCRIPTION
By default `shell-env` uses the login shell to get the environment variables from, this PR adds an optional argument that can be used to override that with a shell of choice.

We need this over at [hyperterm](https://github.com/zeit/hyperterm)

Also, i updated it to use `execa.sync` as stated by the TODO ⭐ 

Should it throw an error if `shell` is passed and can't be executed? 
Instead of silently returning process.env..
