### PR TITLE
Bump execa@0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "default-shell": "^1.0.0",
-    "execa": "^0.4.0",
+    "execa": "^0.5.0",
     "strip-ansi": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Removes the `cross-spawn-async` deprecation warning:

```
npm WARN deprecated cross-spawn-async@2.2.4: cross-spawn no longer requires a build toolchain, use it instead!
```
