### PR TITLE
Upgrade execa

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	],
 	"dependencies": {
 		"default-shell": "^1.0.0",
-		"execa": "^0.8.0",
+		"execa": "^0.10.0",
 		"strip-ansi": "^4.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Since `execa` is on a 0.x.y release, `shell-env` is using an older version of `execa`. I'd love to see this upgraded!