### PR TITLE
use object destructuring to extract stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports.sync = shell => {
 	}
 
 	try {
-		const stdout = execa.sync(shell || defaultShell, args).stdout;
+		const {stdout} = execa.sync(shell || defaultShell, args);
 		return parseEnv(stdout);
 	} catch (err) {
 		if (shell) {


### PR DESCRIPTION
Since #7's Travis run is showing a failure that is unrelated to the changes it's making, I've made a PR to address the lint error:

```
  index.js:41:9
  ✖  41:9  Use object destructuring.  prefer-destructuring
```