### PR TITLE
Compatible with zsh

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ const args = ['-ilc', 'env; exit'];
 function parseEnv(env) {
 	const ret = {};
 
-	for (const line of stripAnsi(env).split('\n')) {
+	const lines = stripAnsi(env).split('\n');
+	lines[0] = lines[0].split(process.env.PWD + '\u0007').pop();
+
+	for (const line of lines) {
 		const parts = line.split('=');
 		ret[parts.shift()] = parts.join('=');
 	}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ const args = ['-ilc', 'env; exit'];
 function parseEnv(env) {
 	const ret = {};
 
-	for (const line of stripAnsi(env).split('\n')) {
+	let lines = stripAnsi(env).split('\n')
+	lines[0] = lines[0].split(process.env.PWD + "\u0007").pop() 
+
+	for (const line of lines) {
 		const parts = line.split('=');
 		ret[parts.shift()] = parts.join('=');
 	}


### PR DESCRIPTION
If user is using `zsh`,`execa.sync(shell,args).stdout` will return an useless header without `\n`.

So we should remove it.

After many tests, I find this useless header always end with `prcess.env.PWD + \u0007`.

```
let lines = stripAnsi(env).split('\n')
lines[0] = lines[0].split(process.env.PWD + "\u0007").pop() 
```
I add this code to ` parseEnv`,it can remove zsh's useless header and no harm for other shell's result.

<img width="1003" alt="screen shot 2018-06-18 at 10 37 41 pm" src="https://user-images.githubusercontent.com/37469825/41547031-b73f98d0-7351-11e8-8f54-b769d338b72f.png">
