### PR TITLE
Refactor TypeScript definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,36 @@
-export interface EnvironmentVariables {
-	readonly [key: string]: string;
+declare namespace shellEnv {
+	interface EnvironmentVariables {
+		readonly [key: string]: string;
+	}
 }
 
-/**
- * Get the environment variables defined in your dotfiles.
- *
- * @param shell - The shell to read environment variables from. Default: User default shell.
- * @returns The environment variables.
- */
-export function sync(shell?: string): EnvironmentVariables;
+declare const shellEnv: {
+	/**
+	Get the environment variables defined in your dotfiles.
 
-/**
- * Get the environment variables defined in your dotfiles.
- *
- * @param shell - The shell to read environment variables from. Default: User default shell.
- * @returns The environment variables.
- */
-export default function shellEnv(shell?: string): Promise<EnvironmentVariables>;
+	@param shell - The shell to read environment variables from. Default: User default shell.
+	@returns The environment variables.
+
+	@example
+	```
+	import shellEnv = require('shell-env');
+
+	console.log(shellEnv.sync());
+	//=> {TERM_PROGRAM: 'Apple_Terminal', SHELL: '/bin/zsh', ...}
+
+	console.log(shellEnv.sync('/bin/bash'));
+	//=> {TERM_PROGRAM: 'iTerm.app', SHELL: '/bin/zsh', ...}
+	```
+	*/
+	(shell?: string): Promise<shellEnv.EnvironmentVariables>;
+
+	/**
+	Get the environment variables defined in your dotfiles.
+
+	@param shell - The shell to read environment variables from. Default: User default shell.
+	@returns The environment variables.
+	*/
+	sync(shell?: string): shellEnv.EnvironmentVariables;
+};
+
+export = shellEnv;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
-import {expectType} from 'tsd-check';
-import shellEnv, {sync, EnvironmentVariables} from '.';
+import {expectType} from 'tsd';
+import shellEnv = require('.');
+import {EnvironmentVariables} from '.';
 
-expectType<EnvironmentVariables>(sync());
-expectType<EnvironmentVariables>(await shellEnv());
+expectType<EnvironmentVariables>(shellEnv.sync());
+expectType<Promise<EnvironmentVariables>>(shellEnv());

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -35,11 +35,11 @@
 	"dependencies": {
 		"default-shell": "^1.0.1",
 		"execa": "^1.0.0",
-		"strip-ansi": "^5.0.0"
+		"strip-ansi": "^5.2.0"
 	},
 	"devDependencies": {
-		"ava": "^1.2.0",
-		"tsd-check": "^0.3.0",
+		"ava": "^1.4.1",
+		"tsd": "^0.7.2",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
**Breaking change**: This module has no default export but declares a default exported function. This is already broken and should be fixed with a major bump.